### PR TITLE
Add admin moderation actions for specialists

### DIFF
--- a/backend/src/controllers/specialistsController.ts
+++ b/backend/src/controllers/specialistsController.ts
@@ -789,6 +789,69 @@ export const getPendingSpecialists = async (req: AuthRequest, res: Response) => 
   }
 };
 
+export const getSpecialistByIdForAdmin = async (req: AuthRequest, res: Response) => {
+  try {
+    if (!req.user || req.user.role !== "admin") {
+      return res.status(403).json({
+        success: false,
+        message: "Недостаточно прав",
+      });
+    }
+
+    const id = sanitizeNumber(req.params.id);
+    if (!id) {
+      return res.status(400).json({
+        success: false,
+        message: "Некорректный id объявления",
+      });
+    }
+
+    const result = await query(
+      `SELECT
+         spec.id,
+         spec.name,
+         spec.specialty,
+         spec.category,
+         spec.description,
+         spec.education,
+         spec.experience,
+         COALESCE(AVG(r.rating), 0)::numeric(3,2) AS rating,
+         spec.location,
+         spec.price_per_hour,
+         spec.avatar_url,
+         spec.created_at,
+         spec.user_id,
+         spec.created_by,
+         spec.is_approved,
+         spec.is_deleted_by_admin,
+         COUNT(r.id)::int AS reviews_total
+       FROM specialists spec
+       LEFT JOIN reviews r ON (r.specialist_id = spec.id AND r.is_approved = TRUE)
+       WHERE spec.id = $1
+       GROUP BY spec.id`,
+      [id]
+    );
+
+    if (!result.rows.length) {
+      return res.status(404).json({
+        success: false,
+        message: "Объявление не найдено",
+      });
+    }
+
+    return res.json({
+      success: true,
+      data: result.rows[0],
+    });
+  } catch (err) {
+    console.error("Ошибка getSpecialistByIdForAdmin:", err);
+    return res.status(500).json({
+      success: false,
+      message: "Ошибка сервера",
+    });
+  }
+};
+
 export const approveSpecialist = async (req: AuthRequest, res: Response) => {
   try {
     if (!req.user || req.user.role !== "admin") {

--- a/backend/src/routes/adminRoutes.ts
+++ b/backend/src/routes/adminRoutes.ts
@@ -1,6 +1,6 @@
 import {Router} from "express";
 import {approveReview, deleteReview, getUnapprovedReviews} from "../controllers/reviewsController";
-import { approveSpecialist, getPendingSpecialists } from "../controllers/specialistsController";
+import { approveSpecialist, getPendingSpecialists, getSpecialistByIdForAdmin } from "../controllers/specialistsController";
 import {authenticateToken, authorize} from "../middleware/auth";
 
 const router = Router();
@@ -9,6 +9,7 @@ router.get('/reviews', getUnapprovedReviews);
 router.post('/review/approve', authenticateToken, authorize('admin'), approveReview);
 router.post('/review/delete', authenticateToken, authorize('admin'), deleteReview);
 router.get('/specialists/pending', authenticateToken, authorize('admin'), getPendingSpecialists);
+router.get('/specialists/:id', authenticateToken, authorize('admin'), getSpecialistByIdForAdmin);
 router.post('/specialists/:id/approve', authenticateToken, authorize('admin'), approveSpecialist);
 
 export default router;

--- a/frontend/hooks/specialists/useSpecialist.ts
+++ b/frontend/hooks/specialists/useSpecialist.ts
@@ -1,12 +1,16 @@
 import {useEffect, useState} from "react";
 import {type Specialist, specialistApi} from "../../src/api/specialists";
 
-export const useSpecialist = (id: number) => {
+type UseSpecialistOptions = {
+    adminPreview?: boolean;
+};
+
+export const useSpecialist = (id: number, options?: UseSpecialistOptions) => {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [specialist, setSpecialist] = useState<Specialist | null>(null);
 
-    const { fetchByID } = specialistApi;
+    const { fetchByID, fetchByIdForAdminModeration } = specialistApi;
 
     useEffect(() => {
         if (!id) {
@@ -21,7 +25,9 @@ export const useSpecialist = (id: number) => {
             setError(null);
 
             try {
-                const result = await fetchByID(id);
+                const result = options?.adminPreview
+                    ? await fetchByIdForAdminModeration(id)
+                    : await fetchByID(id);
 
                 setSpecialist(result);
                 setLoading(false);
@@ -41,7 +47,7 @@ export const useSpecialist = (id: number) => {
         };
 
         loadData();
-    }, [id,]);
+    }, [id, options?.adminPreview]);
 
     const clearError = () => {
         setError(null)

--- a/frontend/pages/AdminPage.tsx
+++ b/frontend/pages/AdminPage.tsx
@@ -1,12 +1,14 @@
 import { Layout } from "antd";
 import AppHeader from "../src/Header/AppHeader.tsx";
 import ReviewsModerationPanel from "../src/components/admin/ReviewsModerationPanel.tsx";
+import SpecialistsModerationPanel from "../src/components/admin/SpecialistsModerationPanel.tsx";
 
 const AdminPage = () => {
     return (
         <Layout>
             <AppHeader/>
             <div style={{ padding: "24px", maxWidth: 1200, margin: "0 auto" }}>
+              <SpecialistsModerationPanel cardStyle={{ marginBottom: 16 }} />
               <ReviewsModerationPanel />
             </div>
         </Layout>

--- a/frontend/pages/SpecialistPage.tsx
+++ b/frontend/pages/SpecialistPage.tsx
@@ -1,6 +1,6 @@
 import {Layout, Row, Col} from "antd";
 import AppHeader from "../src/Header/AppHeader";
-import {useParams} from "react-router-dom";
+import {useParams, useSearchParams} from "react-router-dom";
 import {SpecialistMainInfoCard} from "../src/components/specialist/SpecialistMainInfoCard.tsx";
 import {SpecialistDescription} from "../src/components/specialist/SpecialistDescription.tsx";
 import {SpecialistBooking} from "../src/components/specialist/SpecialistBooking.tsx";
@@ -13,7 +13,9 @@ const { Content } = Layout;
 
 const SpecialistPage = () => {
     const { id } = useParams();
-    const { specialist, loading, error } = useSpecialist(Number(id));
+    const [searchParams] = useSearchParams();
+    const isAdminPreview = searchParams.get("adminPreview") === "1";
+    const { specialist, loading, error } = useSpecialist(Number(id), { adminPreview: isAdminPreview });
 
     if (loading) {
         return <div style={{ color: 'black', textAlign: 'center', padding: '40px' }}>Загрузка...</div>;

--- a/frontend/src/api/specialists.ts
+++ b/frontend/src/api/specialists.ts
@@ -32,13 +32,21 @@ export interface ApiResponse<T> {
   message?: string;
 }
 
+async function parseJsonSafe<T>(response: Response, fallback: T): Promise<T> {
+  try {
+    return (await response.json()) as T;
+  } catch {
+    return fallback;
+  }
+}
+
 export const specialistApi = {
   fetchAll: async (): Promise<Specialist[]> => {
     const response = await fetch(`${API_BASE_URL}/api/specialists`);
     if (!response.ok) {
       throw new Error(`Ошибка HTTP при получении специалистов: ${response.status}`);
     }
-    const result: ApiResponse<Specialist[]> = await response.json();
+    const result = await parseJsonSafe<ApiResponse<Specialist[]>>(response, { success: false });
     
     if (!result.success || !result.data) {
       throw new Error(result.message || "Ошибка формата данных");
@@ -51,14 +59,14 @@ export const specialistApi = {
     const response = await fetch(`${API_BASE_URL}/api/specialists/${id}`);
     
     if (response.status === 410) {
-      const result: any = await response.json();
+      const result = await parseJsonSafe<any>(response, {});
       throw new Error(result.message || 'Это объявление было удалено администратором');
     }
     
     if (!response.ok) {
       throw new Error(`Ошибка HTTP при получении специалиста: ${response.status}`);
     }
-    const result: ApiResponse<Specialist> = await response.json();
+    const result = await parseJsonSafe<ApiResponse<Specialist>>(response, { success: false });
 
     if (!result.success || !result.data) {
       throw new Error(result.message || "Ошибка формата данных");
@@ -66,6 +74,35 @@ export const specialistApi = {
 
     // DEBUG: Temporary log to see what the frontend gets
     // console.log("Fetched specialist successfully:", result.data);
+
+    return result.data;
+  },
+
+  fetchByIdForAdminModeration: async (id: number): Promise<Specialist> => {
+    const accessToken = localStorage.getItem('accessToken');
+    if (!accessToken) {
+      throw new Error('UNAUTHORIZED');
+    }
+
+    const response = await fetch(`${API_BASE_URL}/api/admin/specialists/${id}`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      useAuthStore.getState().logout();
+      throw new Error('UNAUTHORIZED');
+    }
+
+    if (!response.ok) {
+      throw new Error(`Ошибка HTTP при получении объявления: ${response.status}`);
+    }
+
+    const result = await parseJsonSafe<ApiResponse<Specialist>>(response, { success: false });
+    if (!result.success || !result.data) {
+      throw new Error(result.message || "Ошибка формата данных");
+    }
 
     return result.data;
   },
@@ -82,7 +119,7 @@ export const specialistApi = {
       throw new Error(`Ошибка HTTP при поиске специалистов: ${response.status}`);
     }
     
-    const result: ApiResponse<Specialist[]> = await response.json();
+    const result = await parseJsonSafe<ApiResponse<Specialist[]>>(response, { success: false });
     
     if (!result.success) {
       throw new Error(result.message || "Ошибка формата данных при поиске");
@@ -111,7 +148,7 @@ export const specialistApi = {
       throw new Error(`Ошибка загрузки ваших объявлений: ${response.status}`);
     }
     
-    const result = await response.json();
+    const result = await parseJsonSafe<ApiResponse<Specialist[]>>(response, { success: false, data: [] });
     return result.data || [];
   },
 
@@ -129,11 +166,11 @@ export const specialistApi = {
     }
     
     if (!response.ok) {
-      const result = await response.json().catch(() => ({}));
+      const result = await parseJsonSafe<{ message?: string }>(response, {});
       throw new Error(result.message || "Ошибка при обновлении специалиста");
     }
 
-    const result: ApiResponse<Specialist> = await response.json();
+    const result = await parseJsonSafe<ApiResponse<Specialist>>(response, { success: false });
     if (!result.success || !result.data) {
       throw new Error(result.message || "Ошибка при обновлении специалиста");
     }
@@ -153,11 +190,11 @@ export const specialistApi = {
     }
 
     if (!response.ok) {
-      const result = await response.json().catch(() => ({}));
+      const result = await parseJsonSafe<{ message?: string }>(response, {});
       throw new Error(result.message || "Ошибка при удалении аватара");
     }
 
-    const result: ApiResponse<Specialist> = await response.json();
+    const result = await parseJsonSafe<ApiResponse<Specialist>>(response, { success: false });
     if (!result.success || !result.data) {
       throw new Error(result.message || "Ошибка при удалении аватара");
     }
@@ -182,7 +219,7 @@ export const specialistApi = {
     if (!response.ok) {
       // Пытаемся вытащить понятное сообщение об ошибке с бэкенда
       try {
-        const json: ApiResponse<null> = await response.json();
+        const json = await parseJsonSafe<ApiResponse<null>>(response, { success: false });
         throw new Error(json.message || `Ошибка HTTP при удалении специалиста: ${response.status}`);
       } catch {
         const text = await response.text().catch(() => '');
@@ -190,7 +227,7 @@ export const specialistApi = {
       }
     }
 
-    const result: ApiResponse<null> = await response.json().catch(() => ({ success: true }));
+    const result = await parseJsonSafe<ApiResponse<null>>(response, { success: true });
     if (result.success === false) {
       throw new Error(result.message || 'Не удалось удалить специалиста');
     }
@@ -217,7 +254,7 @@ export const specialistApi = {
       throw new Error(`Ошибка HTTP при получении уведомлений: ${response.status}`);
     }
 
-    const result: ApiResponse<SpecialistDeletionNotice[]> = await response.json();
+    const result = await parseJsonSafe<ApiResponse<SpecialistDeletionNotice[]>>(response, { success: false });
     if (!result.success) {
       throw new Error(result.message || 'Не удалось получить уведомления');
     }
@@ -246,7 +283,7 @@ export const specialistApi = {
       throw new Error(`Ошибка HTTP при получении объявлений на модерации: ${response.status}`);
     }
 
-    const result: ApiResponse<Specialist[]> = await response.json();
+    const result = await parseJsonSafe<ApiResponse<Specialist[]>>(response, { success: false });
     if (!result.success) {
       throw new Error(result.message || 'Не удалось получить объявления на модерации');
     }
@@ -273,16 +310,25 @@ export const specialistApi = {
     }
 
     if (!response.ok) {
-      const result = await response.json().catch(() => ({}));
+      const result = await parseJsonSafe<{ message?: string }>(response, {});
       throw new Error(result.message || 'Не удалось одобрить объявление');
     }
 
-    const result: ApiResponse<Specialist> = await response.json();
+    const result = await parseJsonSafe<ApiResponse<Specialist>>(response, { success: false });
     if (!result.success || !result.data) {
       throw new Error(result.message || 'Не удалось одобрить объявление');
     }
 
     return result.data;
+  },
+
+  adminDeleteSpecialist: async (id: number, reason: string): Promise<void> => {
+    const accessToken = localStorage.getItem('accessToken');
+    if (!accessToken) {
+      throw new Error('UNAUTHORIZED');
+    }
+
+    await specialistApi.deleteById(id, accessToken, reason);
   },
 
   acknowledgeDeletionNotice: async (id: number): Promise<void> => {
@@ -307,7 +353,7 @@ export const specialistApi = {
       throw new Error(`Ошибка HTTP при подтверждении уведомления: ${response.status}`);
     }
 
-    const result: ApiResponse<null> = await response.json().catch(() => ({ success: true }));
+    const result = await parseJsonSafe<ApiResponse<null>>(response, { success: true });
     if (result.success === false) {
       throw new Error(result.message || 'Не удалось подтвердить уведомление');
     }

--- a/frontend/src/components/admin/SpecialistsModerationPanel.tsx
+++ b/frontend/src/components/admin/SpecialistsModerationPanel.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
-import { Avatar, Button, Card, Empty, message, Space, Tag, Typography } from "antd";
+import { Avatar, Button, Card, Empty, Input, message, Modal, Space, Tag, Typography } from "antd";
 import { UserOutlined } from "@ant-design/icons";
 import { specialistApi, type Specialist } from "../../api/specialists";
+import { useNavigate } from "react-router-dom";
 
 const { Title, Text, Paragraph } = Typography;
 
@@ -17,6 +18,8 @@ export default function SpecialistsModerationPanel({
   const [specialists, setSpecialists] = useState<Specialist[]>([]);
   const [loading, setLoading] = useState(false);
   const [approvingId, setApprovingId] = useState<number | null>(null);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+  const navigate = useNavigate();
 
   const total = useMemo(() => specialists.length, [specialists]);
 
@@ -49,6 +52,47 @@ export default function SpecialistsModerationPanel({
     } finally {
       setApprovingId(null);
     }
+  };
+
+  const handleDelete = (spec: Specialist) => {
+    let reason = "";
+
+    Modal.confirm({
+      title: `Удалить объявление "${spec.name}"?`,
+      okText: "Удалить",
+      cancelText: "Отмена",
+      okButtonProps: { danger: true },
+      content: (
+        <Input.TextArea
+          rows={4}
+          placeholder="Укажите причину удаления (минимум 5 символов)"
+          onChange={(e) => {
+            reason = e.target.value;
+          }}
+        />
+      ),
+      onOk: async () => {
+        if (reason.trim().length < 5) {
+          message.error("Укажите причину удаления (минимум 5 символов)");
+          return Promise.reject(new Error("INVALID_REASON"));
+        }
+
+        try {
+          setDeletingId(spec.id);
+          await specialistApi.adminDeleteSpecialist(spec.id, reason.trim());
+          setSpecialists((prev) => prev.filter((item) => item.id !== spec.id));
+          message.success("Объявление удалено");
+        } catch (error: unknown) {
+          const err = error instanceof Error ? error : null;
+          message.error(err?.message || "Не удалось удалить объявление");
+          return Promise.reject(error);
+        } finally {
+          setDeletingId(null);
+        }
+
+        return undefined;
+      },
+    });
   };
 
   return (
@@ -96,13 +140,21 @@ export default function SpecialistsModerationPanel({
                     </div>
                   </Space>
 
-                  <Button
-                    type="primary"
-                    loading={approvingId === spec.id}
-                    onClick={() => handleApprove(spec.id)}
-                  >
-                    Одобрить
-                  </Button>
+                  <Space>
+                    <Button onClick={() => navigate(`/specialists/${spec.id}?adminPreview=1`)}>
+                      Просмотреть
+                    </Button>
+                    <Button danger loading={deletingId === spec.id} onClick={() => handleDelete(spec)}>
+                      Удалить
+                    </Button>
+                    <Button
+                      type="primary"
+                      loading={approvingId === spec.id}
+                      onClick={() => handleApprove(spec.id)}
+                    >
+                      Одобрить
+                    </Button>
+                  </Space>
                 </Space>
 
                 <Paragraph style={{ marginTop: 12, marginBottom: 0 }} ellipsis={{ rows: 3, expandable: true }}>
@@ -113,6 +165,7 @@ export default function SpecialistsModerationPanel({
           </Space>
         )}
       </div>
+
     </Card>
   );
 }


### PR DESCRIPTION
Allow admins to open pending specialist cards from moderation and delete pending announcements with a reason.